### PR TITLE
Let's only strip trailing whitespace when parsing command

### DIFF
--- a/src/command/command.c
+++ b/src/command/command.c
@@ -1844,7 +1844,7 @@ cmd_process_input(char *inp)
 {
     log_debug("Input received: %s", inp);
     gboolean result = FALSE;
-    g_strstrip(inp);
+    g_strchomp(inp);
 
     // just carry on if no input
     if (strlen(inp) == 0) {


### PR DESCRIPTION
Allows for "quoting" a command--doing nothing but sending the string: SPC/command
As we're used to from for example irc clients. 

Fixes boothj5/profanity#513